### PR TITLE
Edit action behavior for use with EAMxx 

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -29,6 +29,9 @@ inputs:
     description: 'Just fix files (`clang-format -i`) instead of returning a diff'
     required: false
     default: False
+outputs:
+  files:
+    description: 'files that fail clang-format'
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/run-clang-format.py
+++ b/run-clang-format.py
@@ -194,7 +194,7 @@ def run_clang_format_diff(args, file):
             ),
             errs,
         )
-    return make_diff(file, original, outs), errs, file
+    return make_diff(file, original, outs), errs, file, invocation
 
 
 def bold_red(s):
@@ -370,6 +370,10 @@ def main():
 
     if not args.quiet:
       print('Processing %s files: %s' % (len(files), ', '.join(files)))
+      print()
+      print(f'Invoking clang-format as: '
+            + f'{os.path.basename(args.clang_format_executable)} '
+            + f'--style={args.style} <path-to-file>')
 
     njobs = args.j
     if njobs == 0:
@@ -389,7 +393,7 @@ def main():
     diff_files = []
     while True:
         try:
-            outs, errs, file = next(it)
+            outs, errs, file, invocation = next(it)
         except StopIteration:
             break
         except DiffError as e:
@@ -426,6 +430,12 @@ def main():
             for ff in diff_files:
                 print(f'{ff}', file=fh)
             print('```', file=fh)
+            print('', file=fh)
+            print(f'Execute `{os.path.basename(args.clang_format_executable)} '
+                  + f'--style={args.style} <path-to-file>` to print '
+                  + f'formatted file to `stdout`.', file=fh)
+            print('Include the `-i` (in-place) option to replace the original '
+                  + 'file with the formatted version.', file=fh)
     else:
         with open(os.environ['GITHUB_STEP_SUMMARY'], 'a') as fh:
             print('## Status: `clang-format` Check Passed!', file=fh)


### PR DESCRIPTION
The primary change is to print a step summary to the workflow page.

---

Details:

- Step summary includes:
  - Pass/fail status
  - Paths to any files that fail check
  - Description of how to invoke `clang-format` to produce passing results. (i.e., the invocation)
- The invocation is also printed to the workflow console at the beginning of the action.