### PR TITLE
Control whether `GITHUB_STEP_SUMMARY` is written via `write_summary` input

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -29,6 +29,10 @@ inputs:
     description: 'Just fix files (`clang-format -i`) instead of returning a diff'
     required: false
     default: False
+  write_summary:
+    description: 'Write summary of Pass or Fail and failing files to GITHUB_STEP_SUMMARY'
+    required: false
+    default: True
 outputs:
   files:
     description: 'files that fail clang-format'
@@ -50,3 +54,5 @@ runs:
     - --exclude
     - ${{ inputs.exclude }}
     - ${{ inputs.source }}
+    - --write_summary
+    - ${{ inputs.write_summary }}

--- a/run-clang-format.py
+++ b/run-clang-format.py
@@ -437,11 +437,17 @@ def main():
                     print(f'{ff}', file=fh)
                 print('```', file=fh)
                 print('', file=fh)
-                print(f'Execute `{os.path.basename(args.clang_format_executable)} '
-                      + f'--style={args.style} <path-to-file>` to print '
-                      + f'formatted file to `stdout`.', file=fh)
-                print('Include the `-i` (in-place) option to replace the original '
-                      + 'file with the formatted version.', file=fh)
+                print('To format all of these files at once, download the '
+                      + 'patch file below, `clang-format-patch_[...].diff`, '
+                      + 'from the ***Artifacts*** section.', file=fh)
+                print('Note that it may take a moment for the file to appear '
+                      + 'or may require reloading the page.', file=fh)
+                print('', file=fh)
+                print('To apply the patch containing the formatting edits, '
+                      + 'execute `git apply <patch-file>` from your local E3SM '
+                      + 'branch.', file=fh)
+                print('Then commit the changes and push to your remote branch.',
+                      file=fh)
         else:
             with open(os.environ['GITHUB_STEP_SUMMARY'], 'a') as fh:
                 print('## Status: `clang-format` Check Passed!', file=fh)

--- a/run-clang-format.py
+++ b/run-clang-format.py
@@ -428,7 +428,7 @@ def main():
                     retcode = ExitStatus.DIFF
 
     if args.write_summary:
-        if retcode > ExitStatus.SUCCESS:
+        if retcode != ExitStatus.SUCCESS:
             with open(os.environ['GITHUB_STEP_SUMMARY'], 'a') as fh:
                 print('## Status: `clang-format` Check Failed.', file=fh)
                 print('The following files require formatting:', file=fh)

--- a/run-clang-format.py
+++ b/run-clang-format.py
@@ -314,6 +314,11 @@ def main():
         type=lambda x: bool(strtobool(x)),
         default=False,
         help='Just fix files (`clang-format -i`) instead of returning a diff')
+    parser.add_argument(
+        '--write_summary',
+        type=lambda x: bool(strtobool(x)),
+        default=True,
+        help='Write summary of Pass or Fail and failing files to GITHUB_STEP_SUMMARY')
 
     args = parser.parse_args()
 
@@ -422,23 +427,24 @@ def main():
                 if retcode == ExitStatus.SUCCESS:
                     retcode = ExitStatus.DIFF
 
-    if retcode > ExitStatus.SUCCESS:
-        with open(os.environ['GITHUB_STEP_SUMMARY'], 'a') as fh:
-            print('## Status: `clang-format` Check Failed.', file=fh)
-            print('The following files require formatting:', file=fh)
-            print('```', file=fh)
-            for ff in diff_files:
-                print(f'{ff}', file=fh)
-            print('```', file=fh)
-            print('', file=fh)
-            print(f'Execute `{os.path.basename(args.clang_format_executable)} '
-                  + f'--style={args.style} <path-to-file>` to print '
-                  + f'formatted file to `stdout`.', file=fh)
-            print('Include the `-i` (in-place) option to replace the original '
-                  + 'file with the formatted version.', file=fh)
-    else:
-        with open(os.environ['GITHUB_STEP_SUMMARY'], 'a') as fh:
-            print('## Status: `clang-format` Check Passed!', file=fh)
+    if args.write_summary:
+        if retcode > ExitStatus.SUCCESS:
+            with open(os.environ['GITHUB_STEP_SUMMARY'], 'a') as fh:
+                print('## Status: `clang-format` Check Failed.', file=fh)
+                print('The following files require formatting:', file=fh)
+                print('```', file=fh)
+                for ff in diff_files:
+                    print(f'{ff}', file=fh)
+                print('```', file=fh)
+                print('', file=fh)
+                print(f'Execute `{os.path.basename(args.clang_format_executable)} '
+                      + f'--style={args.style} <path-to-file>` to print '
+                      + f'formatted file to `stdout`.', file=fh)
+                print('Include the `-i` (in-place) option to replace the original '
+                      + 'file with the formatted version.', file=fh)
+        else:
+            with open(os.environ['GITHUB_STEP_SUMMARY'], 'a') as fh:
+                print('## Status: `clang-format` Check Passed!', file=fh)
 
     return retcode
 


### PR DESCRIPTION
This was necessary to easily output the diff patch.

We choose not to write the summary on the first run, because it formats the files in-place to diff them, but returns a passing status. So we reset and run the formatter again to generate the fail, and list of failing files.